### PR TITLE
Fix: Replace str.removesuffix in older python versions

### DIFF
--- a/src/dig_git_ignore/action/template.py
+++ b/src/dig_git_ignore/action/template.py
@@ -1,4 +1,5 @@
 from typing import Set
+from sys import version_info
 from ..constants import GITIGNORE_FILENAME, CONTENT_BLOCK_START
 
 
@@ -8,6 +9,14 @@ def current() -> Set[str]:
         line = file.readline()
         while line:
             if line.startswith(CONTENT_BLOCK_START):
-                return set(line.removesuffix("\n").split("/").pop().split(","))
+                return set(_remove_suffix(line, "\n").split("/").pop().split(","))
             line = file.readline()
     return output
+
+
+def _remove_suffix(string: str, suffix: str) -> str:
+    if version_info >= (3, 9):
+        return string.removesuffix(suffix)
+    if string.endswith(suffix):
+        return string[: -len(suffix)]
+    return string


### PR DESCRIPTION
Created alternative method to replace str.removesuffix in older python versions